### PR TITLE
Delegate high-tan input validation to numpy

### DIFF
--- a/wellpathpy/high_tan.py
+++ b/wellpathpy/high_tan.py
@@ -24,20 +24,9 @@ def high_tan_method(md, inc, azi):
         `np.insert([tvd, northing, easting], 0, <surface location>)`
     """
     # inputs are array-like
-    try:
-        md = np.array(md) + 0
-    except TypeError:
-        raise TypeError('md must be array-like')
-
-    try:
-        inc = np.array(inc) + 0
-    except TypeError:
-        raise TypeError('inc must be array-like')
-
-    try:
-        azi = np.array(azi) + 0
-    except TypeError:
-        raise TypeError('azi must be array-like')
+    md = np.asarray(md, dtype = np.float)
+    inc = np.asarray(inc, dtype = np.float)
+    azi = np.asarray(azi, dtype = np.float)
 
     # inputs are same length
     try:
@@ -45,21 +34,6 @@ def high_tan_method(md, inc, azi):
     except ZeroDivisionError:
         raise ZeroDivisionError('md, incl and azi must be of same length')
 
-    # inputs dtype are int or float
-    try:
-        md += 0
-    except TypeError:
-        raise TypeError('md array must of dtype int or float')
-
-    try:
-        inc += 0
-    except TypeError:
-        raise TypeError('inc array must of dtype int or float')
-
-    try:
-        azi += 0
-    except TypeError:
-        raise TypeError('azi array must of dtype int or float')
 
     # md array increases strictly at each step
     try:

--- a/wellpathpy/test/test_high_tan.py
+++ b/wellpathpy/test/test_high_tan.py
@@ -5,34 +5,21 @@ from ..high_tan import high_tan_method
 
 # inputs are array-like
 def test_md_throws():
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         _ = high_tan_method(md='lmkcde', inc=[1,2,3], azi=[1,2,3])
 
 def test_inc_throws():
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         _ = high_tan_method(md=[1,2,3], inc='adsda', azi=[1,2,3])
 
 def test_azi_throws():
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         _ = high_tan_method(md=[1,2,3], inc=[1,2,3], azi='kjnef')
 
 # inputs are same length
 def test_input_lengths_throws():
     with pytest.raises(ZeroDivisionError):
         _ = high_tan_method(md=[1,2,3], inc=[1,2,3], azi=[1,2])
-
-# inputs dtype are int or float
-def test_md_dtype_throws():
-    with pytest.raises(TypeError):
-        _ = high_tan_method(md=['1','2','3'], inc=[1,2,3], azi=[1,2,3])
-
-def test_inc_dtype_throws():
-    with pytest.raises(TypeError):
-        _ = high_tan_method(md=[1,2,3], inc=['1','2','3'], azi=[1,2,3])
-
-def test_azi_dtype_throws():
-    with pytest.raises(TypeError):
-        _ = high_tan_method(md=[1,2,3], inc=[1,2,3], azi=['1','2','3'])
 
 # md array increases strictly at each step
 def test_increasing_md_throws():


### PR DESCRIPTION
Use numpy.asarray as the only mechanism for rejecting user input in the
high_tan_method. This simplifies logic a lot, with the added benefit of
accepting more otherwise maybe ok inputs (such as strings-with-floats).

There are two immediate consequences:

1. If the inputs are lists, but not of floats, they now raise
   ValueError, not type error.
2. List-of-strings-of-floats is now considered ok, because numpy can
   convert them.