### PR TITLE
Centralise check array

### DIFF
--- a/wellpathpy/ave_tan.py
+++ b/wellpathpy/ave_tan.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from .checkarrays import checkarrays
+
 def ave_tan_method(md, inc, azi):
     """
     Calculate TVD using average tangential method.
@@ -23,20 +25,7 @@ def ave_tan_method(md, inc, azi):
         replace `np.insert([tvd, northing, easting], 0, 0)` with
         `np.insert([tvd, northing, easting], 0, <surface location>)`
     """
-    # inputs are array-like
-    md = np.asarray(md, dtype = np.float)
-    inc = np.asarray(inc, dtype = np.float)
-    azi = np.asarray(azi, dtype = np.float)
-
-    # inputs are same shape
-    if not (md.shape == inc.shape == azi.shape):
-        raise ValueError('md, inc, and azi must be the same shape')
-
-    # md array increases strictly at each step
-    try:
-        1 / bool(np.all(md[1:] > md[:-1]))
-    except ZeroDivisionError:
-        raise ZeroDivisionError('md must have strictly increasing values')
+    md, inc, azi = checkarrays(md, inc, azi)
 
     # convert degrees to radians for numpy functions
     azi_r = np.deg2rad(azi)

--- a/wellpathpy/bal_tan.py
+++ b/wellpathpy/bal_tan.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from .checkarrays import checkarrays
+
 def bal_tan_method(md, inc, azi):
     """
     Calculate TVD using balanced tangential method.
@@ -23,20 +25,7 @@ def bal_tan_method(md, inc, azi):
         replace `np.insert([tvd, northing, easting], 0, 0)` with
         `np.insert([tvd, northing, easting], 0, <surface location>)`
     """
-    # inputs are array-like
-    md = np.asarray(md, dtype = np.float)
-    inc = np.asarray(inc, dtype = np.float)
-    azi = np.asarray(azi, dtype = np.float)
-
-    # inputs are same shape
-    if not (md.shape == inc.shape == azi.shape):
-        raise ValueError('md, inc, and azi must be the same shape')
-
-    # md array increases strictly at each step
-    try:
-        1 / bool(np.all(md[1:] > md[:-1]))
-    except ZeroDivisionError:
-        raise ZeroDivisionError('md must have strictly increasing values')
+    md, inc, azi = checkarrays(md, inc, azi)
 
     # convert degrees to radians for numpy functions
     azi_r = np.deg2rad(azi)

--- a/wellpathpy/checkarrays.py
+++ b/wellpathpy/checkarrays.py
@@ -1,0 +1,49 @@
+import numpy as np
+
+def checkarrays(md, inc, azi):
+    """
+    Assure basic preconditions are met, and convert input (md, inc, azi) to
+    numpy arrays.
+
+    This function will ensure that:
+
+    - All inputs are convertible to arrays-of-floats, and perform this
+      conversion
+    - All inputs are of the same shape
+    - md is strictly increasing
+
+    Parameters
+    ----------
+    md: array_like of float
+        measured depth
+    inc: array_like of float
+        well deviation
+    azi: array_like of float
+        azimuth
+
+    Returns
+    -------
+    md: array_like of float
+        measured depth
+    inc: array_like of float
+        well deviation
+    azi: array_like of float
+        azimuth
+
+    Raises
+    ------
+    ValueError
+        If md, inc, or azi, are of different shapes
+        If the md values are not strictly increasing
+    """
+    md = np.asarray(md, dtype = np.float)
+    inc = np.asarray(inc, dtype = np.float)
+    azi = np.asarray(azi, dtype = np.float)
+
+    if not (md.shape == inc.shape == azi.shape):
+        raise ValueError('md, inc, and azi must be the same shape')
+
+    if not np.all(md[1:] > md[:-1]):
+        raise ValueError('md must have strictly increasing values')
+
+    return md, inc, azi

--- a/wellpathpy/high_tan.py
+++ b/wellpathpy/high_tan.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from .checkarrays import checkarrays
+
 def high_tan_method(md, inc, azi):
     """
     Calculate TVD using high tangential method.
@@ -23,20 +25,7 @@ def high_tan_method(md, inc, azi):
         replace `np.insert([tvd, northing, easting], 0, 0)` with
         `np.insert([tvd, northing, easting], 0, <surface location>)`
     """
-    # inputs are array-like
-    md = np.asarray(md, dtype = np.float)
-    inc = np.asarray(inc, dtype = np.float)
-    azi = np.asarray(azi, dtype = np.float)
-
-    # inputs are same shape
-    if not (md.shape == inc.shape == azi.shape):
-        raise ValueError('md, inc, and azi must be the same shape')
-
-    # md array increases strictly at each step
-    try:
-        1 / bool(np.all(md[1:] > md[:-1]))
-    except ZeroDivisionError:
-        raise ZeroDivisionError('md must have strictly increasing values')
+    md, inc, azi = checkarrays(md, inc, azi)
 
     # convert degrees to radians for numpy functions
     azi_r = np.deg2rad(azi)

--- a/wellpathpy/low_tan.py
+++ b/wellpathpy/low_tan.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from .checkarrays import checkarrays
+
 def low_tan_method(md, inc, azi):
     """
     Calculate TVD using low tangential method.
@@ -23,20 +25,7 @@ def low_tan_method(md, inc, azi):
         replace `np.insert([tvd, northing, easting], 0, 0)` with
         `np.insert([tvd, northing, easting], 0, <surface location>)`
     """
-    # inputs are array-like
-    md = np.asarray(md, dtype = np.float)
-    inc = np.asarray(inc, dtype = np.float)
-    azi = np.asarray(azi, dtype = np.float)
-
-    # inputs are same shape
-    if not (md.shape == inc.shape == azi.shape):
-        raise ValueError('md, inc, and azi must be the same shape')
-
-    # md array increases strictly at each step
-    try:
-        1 / bool(np.all(md[1:] > md[:-1]))
-    except ZeroDivisionError:
-        raise ZeroDivisionError('md must have strictly increasing values')
+    md, inc, azi = checkarrays(md, inc, azi)
 
     # convert degrees to radians for numpy functions
     azi_r = np.deg2rad(azi)

--- a/wellpathpy/mincurve.py
+++ b/wellpathpy/mincurve.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from .checkarrays import checkarrays
+
 def min_curve_method(md, inc, azi, md_units='m', norm_opt=0):
     """
     Calculate TVD using minimum curvature method.
@@ -30,20 +32,7 @@ def min_curve_method(md, inc, azi, md_units='m', norm_opt=0):
         replace `np.insert([tvd, northing, easting], 0, 0)` with
         `np.insert([tvd, northing, easting], 0, <surface location>)`
     """
-    # inputs are array-like
-    md = np.asarray(md, dtype = np.float)
-    inc = np.asarray(inc, dtype = np.float)
-    azi = np.asarray(azi, dtype = np.float)
-
-    # inputs are same shape
-    if not (md.shape == inc.shape == azi.shape):
-        raise ValueError('md, inc, and azi must be the same shape')
-
-    # md array increases strictly at each step
-    try:
-        1 / bool(np.all(md[1:] > md[:-1]))
-    except ZeroDivisionError:
-        raise ZeroDivisionError('md must have strictly increasing values')
+    md, inc, azi = checkarrays(md, inc, azi)
 
     # get units and normalising for dls
     try:

--- a/wellpathpy/rad_curv.py
+++ b/wellpathpy/rad_curv.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from .checkarrays import checkarrays
+
 def rad_curve_method(md, inc, azi):
     """
     Calculate TVD using radius or curvature method.
@@ -25,20 +27,7 @@ def rad_curve_method(md, inc, azi):
         replace `np.insert([tvd, northing, easting], 0, 0)` with
         `np.insert([tvd, northing, easting], 0, <surface location>)`
     """
-    # inputs are array-like
-    md = np.asarray(md, dtype = np.float)
-    inc = np.asarray(inc, dtype = np.float)
-    azi = np.asarray(azi, dtype = np.float)
-
-    # inputs are same shape
-    if not (md.shape == inc.shape == azi.shape):
-        raise ValueError('md, inc, and azi must be the same shape')
-
-    # md array increases strictly at each step
-    try:
-        1 / bool(np.all(md[1:] > md[:-1]))
-    except ZeroDivisionError:
-        raise ZeroDivisionError('md must have strictly increasing values')
+    md, inc, azi = checkarrays(md, inc, azi)
 
     # convert degrees to radians for numpy functions
     azi_r = np.deg2rad(azi)

--- a/wellpathpy/test/test_ave_tan.py
+++ b/wellpathpy/test/test_ave_tan.py
@@ -23,5 +23,5 @@ def test_input_lengths_throws():
 
 # md array increases strictly at each step
 def test_increasing_md_throws():
-    with pytest.raises(ZeroDivisionError):
+    with pytest.raises(ValueError):
         _ = ave_tan_method(md=[1,1,3], inc=[1,2,3], azi=[1,2,3])

--- a/wellpathpy/test/test_bal_tan.py
+++ b/wellpathpy/test/test_bal_tan.py
@@ -23,5 +23,5 @@ def test_input_lengths_throws():
 
 # md array increases strictly at each step
 def test_increasing_md_throws():
-    with pytest.raises(ZeroDivisionError):
+    with pytest.raises(ValueError):
         _ = bal_tan_method(md=[1,1,3], inc=[1,2,3], azi=[1,2,3])

--- a/wellpathpy/test/test_high_tan.py
+++ b/wellpathpy/test/test_high_tan.py
@@ -23,5 +23,5 @@ def test_input_lengths_throws():
 
 # md array increases strictly at each step
 def test_increasing_md_throws():
-    with pytest.raises(ZeroDivisionError):
+    with pytest.raises(ValueError):
         _ = high_tan_method(md=[1,1,3], inc=[1,2,3], azi=[1,2,3])

--- a/wellpathpy/test/test_low_tan.py
+++ b/wellpathpy/test/test_low_tan.py
@@ -23,5 +23,5 @@ def test_input_lengths_throws():
 
 # md array increases strictly at each step
 def test_increasing_md_throws():
-    with pytest.raises(ZeroDivisionError):
+    with pytest.raises(ValueError):
         _ = low_tan_method(md=[1,1,3], inc=[1,2,3], azi=[1,2,3])

--- a/wellpathpy/test/test_mincurve.py
+++ b/wellpathpy/test/test_mincurve.py
@@ -23,7 +23,7 @@ def test_input_lengths_throws():
 
 # md array increases strictly at each step
 def test_increasing_md_throws():
-    with pytest.raises(ZeroDivisionError):
+    with pytest.raises(ValueError):
         _ = min_curve_method(md=[1,1,3], inc=[1,2,3], azi=[1,2,3])
 
 # get units for dls

--- a/wellpathpy/test/test_rad_curve.py
+++ b/wellpathpy/test/test_rad_curve.py
@@ -23,5 +23,5 @@ def test_input_lengths_throws():
 
 # md array increases strictly at each step
 def test_increasing_md_throws():
-    with pytest.raises(ZeroDivisionError):
+    with pytest.raises(ValueError):
         _ = rad_curve_method(md=[1,1,3], inc=[1,2,3], azi=[1,2,3])


### PR DESCRIPTION
Add the function checkarray, and centralise basic type normalisation and input verification. A lot of removed duplication across the various methods, which all have the same preconditions.

ZeroDivisionErrors have been changed to the more appropriate ValueError.

```
    Assure basic preconditions are met, and convert input (md, inc, azi) to
    numpy arrays.

    This function will ensure that:

    - All inputs are convertible to arrays-of-floats, and perform this
      conversion
    - All inputs are of the same shape
    - md is strictly increasing

    Parameters
    ----------
    md: array_like of float
        measured depth
    inc: array_like of float
        well deviation
    azi: array_like of float
        azimuth

    Returns
    -------
    md: array_like of float
        measured depth
    inc: array_like of float
        well deviation
    azi: array_like of float
        azimuth

    Raises
    ------
    ValueError
        If md, inc, or azi, are of different shapes
        If the md values are not strictly increasing
```