### PR TITLE
Support arbitrary columns in read_csv

### DIFF
--- a/wellpathpy/__init__.py
+++ b/wellpathpy/__init__.py
@@ -18,8 +18,9 @@ __all__ = [
     'loc_to_zero',
     'loc_to_tvdss',
     'deviation_to_csv',
-    'position_to_csv'
-    ]
+    'position_to_csv',
+    'deviation',
+]
 
 from .convert import unit_convert
 from .header import read_header_json
@@ -30,3 +31,4 @@ from .rad_curv import radius_curvature
 from .read import read_csv
 from .tan import high_tan, low_tan, balanced_tan, average_tan
 from .write import deviation_to_csv, position_to_csv
+from .position_log import deviation

--- a/wellpathpy/position_log.py
+++ b/wellpathpy/position_log.py
@@ -1,0 +1,95 @@
+import numpy as np
+
+from .checkarrays import checkarrays
+from .mincurve import minimum_curvature as mincurve
+from . import location
+
+class deviation:
+    """
+
+    The deviation is a glorified triple (md, inc, azi), with some interesting
+    operations.
+
+    Notes
+    -----
+    Glossary:
+    md : measured depth
+    inc : inclination (in degrees)
+    azi : azimuth (in degrees)
+    """
+    def __init__(self, md, inc, azi):
+        md, inc, azi = checkarrays(md, inc, azi)
+        self.md = np.copy(md)
+        self.inc = np.copy(inc)
+        self.azi = np.copy(azi)
+
+    def copy(self):
+        return deviation(self.md, self.inc, self.azi)
+
+    def minimum_curvature(self, course_length = 30):
+        tvd, n, e, dls = mincurve(
+            md = self.md,
+            inc = self.inc,
+            azi = self.azi,
+            course_length = course_length,
+        )
+        return minimum_curvature(self, tvd, n, e, dls)
+
+class position_log:
+    """Position log
+
+    The position log is the computed positions of the well path. It has no
+    memory of the method that created it, but it knows what deviation it came
+    from. In its essence, it's a glorified triplet (tvd, northing, easting)
+    with some interesting operations.
+
+    Notes
+    -----
+    Glossary:
+    tvd : true vertical depth
+    """
+    def __init__(self, src, tvd, northing, easting):
+        """
+
+        Parameters
+        ----------
+        src : deviation
+        tvd : array_like
+        northing : array_like
+        easting : array_like
+        """
+        self.source = src.copy()
+        self.tvd = tvd
+        self.northing = northing
+        self.easting = easting
+
+    def to_wellhead(self, surface_northing, surface_easting):
+        """Shift position to wellhead location in-place
+
+        Parameters
+        ----------
+        surface_northing : array_like
+        surface_easting : array_like
+        """
+        tvd, n, e = location.loc_to_wellhead(
+            self.tvd,
+            self.northing,
+            self.easting,
+            surface_northing,
+            surface_easting,
+        )
+
+        self.tvd = tvd
+        self.northing = n
+        self.easting = e
+
+    def resample(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def deviation(self):
+        raise NotImplementedError
+
+class minimum_curvature(position_log):
+    def __init__(self, src, tvd, n, e, dls):
+        super().__init__(src, tvd, n, e)
+        self.dls = dls

--- a/wellpathpy/read.py
+++ b/wellpathpy/read.py
@@ -2,37 +2,40 @@ import pandas as pd
 
 from .checkarrays import checkarrays
 
-def read_csv(fname):
+def read_csv(fname, md = 'md', inc = 'inc', azi = 'azi', **kwargs):
     """Read a deviation file in CSV format
+
+    Read a deviation survey from a CSV file. Columns can be specified with the
+    md, inc, and azi parameters.
 
     Parameters
     ----------
     fname : str
         path to a CSV file with this format:
-
-    Notes
-    -----
-    required column names: md, inc, azi
-
-    md : float
-        measured depth (units not defined)
-    inc : float
-        well inclination in degrees from vertical
-    azi : float
-        well azimuth in degrees from North
-
-    The columns md, inc, azi **must** be passed in this order,
-    Other columns are ignored.
+    md : str
+        measured depth column name
+    inc : str
+        inclination column name
+    azi : str
+        azimuth column name
 
     Returns
     -------
     md, inc, azi : tuple
         md, inc and azi are of type np.ndarray
 
+    Notes
+    -----
+    md : float
+        measured depth (units not defined)
+    inc : float
+        well inclination in degrees from vertical
+    azi : float
+        well azimuth in degrees from North
     """
-    df = pd.read_csv(fname, header=0)
+    df = pd.read_csv(fname, header=0, **kwargs)
 
-    md, inc, azi = df['md'].values, df['inc'].values, df['azi'].values
+    md, inc, azi = df[md].values, df[inc].values, df[azi].values
     md, inc, azi = checkarrays(md, inc, azi)
 
     return md, inc, azi

--- a/wellpathpy/test/test_read.py
+++ b/wellpathpy/test/test_read.py
@@ -10,6 +10,13 @@ good_data = '''md,inc,azi
     3,15,258
     '''
 
+renamed_cols = '''measured-depth,inci,am
+    0,0,244
+    1,11,220
+    2,13,254
+    3,15,258
+    '''
+
 mixed_data = '''azi,md,inc,
     244,0,0
     220,1,11
@@ -93,3 +100,10 @@ def test_nans_throws():
         data = io.StringIO(nans_present)
         with pytest.raises(ValueError):
             _ = read_csv(data)
+
+def test_renamed_columns():
+    data = io.StringIO(renamed_cols)
+    md = 'measured-depth'
+    inc = 'inci'
+    azi = 'am'
+    _ = read_csv(data, md = md, inc = inc, azi = azi)

--- a/wellpathpy/test/test_workflow.py
+++ b/wellpathpy/test/test_workflow.py
@@ -1,0 +1,35 @@
+import pytest
+
+from .. import deviation
+from .. import read_csv
+from .. import unit_convert
+
+def test_workflow_compute_mincurve():
+    """
+    Simple, minimal workflow over well9 - read deviation survey, and compute
+    the position log with min-curve. It's a simple, but complete workflow, and
+    the test checks that at least this code paths still works. The correctness
+    of computation should be covered by other tests.
+    """
+    fname = 'wellpathpy/test/fixtures/well9.csv'
+    with open(fname) as f:
+        md_col = 'Measured Depth ( ft )'
+        inc_col = 'Inclination ( deg )'
+        azi_col = 'Azimuth Grid ( deg )'
+        md, inc, azi = read_csv(f, md = md_col, inc = inc_col, azi = azi_col)
+
+    md = unit_convert(md, src = 'ft', dst ='m')
+    dev = deviation(md, inc, azi)
+    pos = dev.minimum_curvature(course_length = 30)
+    pos.to_wellhead(39998.454, 655701.278)
+
+    # expected reference values, from the last row of the CSV
+    # simple sanity checks so it's not all bonkers
+    expected_tvd  = 3489.3174919404673 * 0.3048
+    expected_easting = 655870.4178517371
+    expected_northing = 38631.13241000773
+    expected_dls = 0.871150714388663
+    assert pos.tvd[-1] == pytest.approx(expected_tvd)
+    assert pos.northing[-1] == pytest.approx(expected_northing, abs = 0.5)
+    assert pos.easting[-1] == pytest.approx(expected_easting)
+    assert pos.dls[-1] == pytest.approx(expected_dls, abs = 1)


### PR DESCRIPTION
Instead of fixing read_csv to the column names md, inc, and azi, default
to them instead, and allow just-in-time specification. Usually, it's
easier to change small programs, e.g. in notebooks, than it is to change
data files.