### PR TITLE
Remove deprecated imports from __init__.py

### DIFF
--- a/wellpathpy/__init__.py
+++ b/wellpathpy/__init__.py
@@ -8,15 +8,6 @@ __all__ = [
     'read_header_json',
     'read_csv',
     'unit_convert',
-    'minimum_curvature',
-    'radius_curvature',
-    'high_tan',
-    'low_tan',
-    'balanced_tan',
-    'average_tan',
-    'loc_to_wellhead',
-    'loc_to_zero',
-    'loc_to_tvdss',
     'deviation_to_csv',
     'position_to_csv',
     'deviation',
@@ -25,11 +16,6 @@ __all__ = [
 
 from .convert import unit_convert
 from .header import read_header_json
-from .interpolate import resample_deviation, resample_position
-from .location import loc_to_wellhead, loc_to_zero, loc_to_tvdss
-from .mincurve import minimum_curvature
-from .rad_curv import radius_curvature
 from .read import read_csv
-from .tan import high_tan, low_tan, balanced_tan, average_tan
 from .write import deviation_to_csv, position_to_csv
 from .position_log import deviation, position_log


### PR DESCRIPTION
These methods were difficult to use and have been made
obsolete by the adition of Deviation and Position_log
objects and associated methods for transformation from
one to the other.