### PR TITLE
minimum_curvature.deviation()

### DIFF
--- a/wellpathpy/geometry.py
+++ b/wellpathpy/geometry.py
@@ -16,10 +16,10 @@ def direction_vector(inc, azi):
 
     Returns
     -------
-    vd : array_like of float
-        vertial direction
     northing : array_like of float
     easting : array_like of float
+    vd : array_like of float
+        vertial direction
 
     Examples
     --------
@@ -42,7 +42,7 @@ def direction_vector(inc, azi):
     northing = np.sin(inc) * np.cos(az)
     easting  = np.sin(inc) * np.sin(az)
 
-    return vd, northing, easting
+    return northing, easting, vd
 
 def spherical(northing, easting, depth):
     """[N E V] -> (inc, azi)

--- a/wellpathpy/position_log.py
+++ b/wellpathpy/position_log.py
@@ -197,7 +197,7 @@ class minimum_curvature(position_log):
         --------
         Resample onto a regular, 1m measured depth interval:
 
-        >>> depths = list(range(int(dev.md[-1])) + 1)
+        >>> depths = list(range(int(dev.md[-1]) + 1))
         >>> resampled = pos.resample(depths = depths)
         """
         # break the well path into its survey stations, upper and lower, and

--- a/wellpathpy/position_log.py
+++ b/wellpathpy/position_log.py
@@ -66,7 +66,10 @@ class position_log:
         self.resampled_md = None
 
     def copy(self):
-        return position_log(self.source, np.copy(self.depth), np.copy(self.northing), np.copy(self.easting))
+        l = position_log(self.source, np.copy(self.depth), np.copy(self.northing), np.copy(self.easting))
+        if self.resampled_md is not None:
+            l.resampled_md = np.copy(self.resampled_md)
+        return l
 
     def to_wellhead(self, surface_northing, surface_easting):
         """Create a new position log instance moved to the wellhead location
@@ -171,7 +174,10 @@ class minimum_curvature(position_log):
         self.dls = dls
 
     def copy(self):
-        return minimum_curvature(self.source, np.copy(self.depth), np.copy(self.northing), np.copy(self.easting), np.copy(self.dls))
+        l = minimum_curvature(self.source, np.copy(self.depth), np.copy(self.northing), np.copy(self.easting), np.copy(self.dls))
+        if self.resampled_md is not None:
+            l.resampled_md = np.copy(self.resampled_md)
+        return l
 
     def resample(self, depths):
         """

--- a/wellpathpy/test/test_calculations.py
+++ b/wellpathpy/test/test_calculations.py
@@ -174,6 +174,6 @@ def test_position_log_interface_mincurve():
     pos = pos.resample(depths = md)
     pos.to_wellhead(surface_northing = 39998.454, surface_easting = 655701.278)
 
-    np.testing.assert_allclose(pos.depth,      well9_true_tvd_m,    atol=1)
+    np.testing.assert_allclose(pos.depth,    well9_true_tvd_m,    atol=1)
     np.testing.assert_allclose(pos.northing, well9_true_northing, atol=1)
     np.testing.assert_allclose(pos.easting,  well9_true_easting,  atol=1)

--- a/wellpathpy/test/test_calculations.py
+++ b/wellpathpy/test/test_calculations.py
@@ -177,3 +177,24 @@ def test_position_log_interface_mincurve():
     np.testing.assert_allclose(pos.depth,    well9_true_tvd_m,    atol=1)
     np.testing.assert_allclose(pos.northing, well9_true_northing, atol=1)
     np.testing.assert_allclose(pos.easting,  well9_true_easting,  atol=1)
+
+def test_roundtrip(atol = 0.01):
+    """
+    This pretty much only tests the mincurve, but packed in the
+    deviation+position_log interface
+    """
+    md = well9_true_md_m
+    inc = well9_true_inc
+    azi = well9_true_azi
+
+    dev = deviation(md, inc, azi)
+    pos = dev.minimum_curvature()
+    dev2 = pos.deviation()
+    np.testing.assert_allclose(dev.md,  dev2.md,  atol = atol)
+    np.testing.assert_allclose(dev.inc, dev2.inc, atol = atol)
+    np.testing.assert_allclose(dev.azi, dev2.azi, atol = atol)
+
+    pos.to_wellhead(surface_northing = 39998.454, surface_easting = 655701.278)
+    np.testing.assert_allclose(pos.depth,    well9_true_tvd_m,    atol=1)
+    np.testing.assert_allclose(pos.northing, well9_true_northing, atol=1)
+    np.testing.assert_allclose(pos.easting,  well9_true_easting,  atol=1)

--- a/wellpathpy/test/test_geometry.py
+++ b/wellpathpy/test/test_geometry.py
@@ -11,18 +11,18 @@ from ..geometry import direction_vector
 
 @given(floats(allow_nan=False, allow_infinity=False), floats(allow_nan=False, allow_infinity=False))
 def test_unit_vector_domain(inc, azi):
-    vd, northing, easting = direction_vector(inc, azi)
+    northing, easting, vd = direction_vector(inc, azi)
     assert -1 <= vd <= 1
     assert -1 <= northing <= 1
     assert -1 <= easting <= 1
 
 @given(floats(allow_nan=False, allow_infinity=False))
 def test_zero_inc_yields_vertical_nev(azi):
-    assert direction_vector(0.0, azi) == (1, 0, 0)
+    assert direction_vector(0.0, azi) == (0, 0, 1)
 
 @given(floats(allow_nan=False, allow_infinity=False))
 def test_zero_azi_fixes_easting(inc):
-    vd, northing, easting = direction_vector(inc, 0.0)
+    northing, easting, vd = direction_vector(inc, 0.0)
     assert -1 <= vd <= 1
     assert -1 <= northing <= 1
     assert easting == 0
@@ -30,19 +30,19 @@ def test_zero_azi_fixes_easting(inc):
 #test up/down and cardinal points
 @given(floats(allow_nan=False, allow_infinity=False))
 def test_180_inc_yields_vertical_nev(azi):
-    assert direction_vector(180., azi) == (-1, approx(0), approx(0))
+    assert direction_vector(180., azi) == (approx(0), approx(0), -1)
 
 def test_n_hor_yields_north_nev():
-    assert direction_vector(90., 0) == (approx(0), 1, approx(0))
+    assert direction_vector(90., 0) == (1, approx(0), approx(0))
 
 def test_s_hor_yields_south_nev():
-    assert direction_vector(90., 180.) == (approx(0), -1, approx(0))
+    assert direction_vector(90., 180.) == (-1, approx(0), approx(0))
 
 def test_e_hor_yields_east_nev():
-    assert direction_vector(90., 90.) == (approx(0), approx(0), 1)
+    assert direction_vector(90., 90.) == (approx(0), 1, approx(0))
 
 def test_w_hor_yields_west_nev():
-    assert direction_vector(90., 270.) == (approx(0), approx(0), -1)
+    assert direction_vector(90., 270.) == (approx(0), -1, approx(0))
 
 # Systematic random orientations covering all eight octants
 # we use https://www.wolframalpha.com/ in order to generate
@@ -54,72 +54,72 @@ def test_w_hor_yields_west_nev():
 def test_north_east_up():
     #[x  y  z]
     #[0.43, 0.17, 0.93]
-    vd, n, e = direction_vector(26.436, 21.5713)
+    n, e, v = direction_vector(26.436, 21.5713)
     assert n == approx(0.414017, rel=1e-5)
     assert e == approx(0.163681, rel=1e-5)
-    assert vd == approx(0.895432, rel=1e-5)
+    assert v == approx(0.895432, rel=1e-5)
 
 def test_north_east_down():
     #[x  y -z]
     #[0.75, 0.87, -0.34]
-    vd, n, e = direction_vector(73.5113, 49.2364)
+    n, e, v = direction_vector(73.5113, 49.2364)
     assert n == approx(0.626088, rel=1e-5)
     assert e == approx(0.726262, rel=1e-5)
-    assert vd == approx(0.283827, rel=1e-5)
+    assert v == approx(0.283827, rel=1e-5)
 
 def test_south_east_up():
     #[x -y  z]
     #[0.86, -0.34, 0.65]
-    vd, n, e = direction_vector(54.8975, -21.5713)
+    n, e, v = direction_vector(54.8975, -21.5713)
     assert n == approx(0.760824, rel=1e-5)
     assert e == approx(-0.300791, rel=1e-5)
-    assert vd == approx(0.575041, rel=1e-5)
+    assert v == approx(0.575041, rel=1e-5)
 
 def test_south_east_down():
     #[x -y -z]
     #[0.88, -0.98, -0.97]
-    vd, n, e = direction_vector(53.63, -48.0775)
+    n, e, v = direction_vector(53.63, -48.0775)
     assert n == approx(0.537977, rel=1e-5)
     assert e == approx(-0.599111, rel=1e-5)
-    assert vd == approx(0.592998, rel=1e-5)
+    assert v == approx(0.592998, rel=1e-5)
 
 def test_north_west_up():
     #[-x  y  z]
     #[-0.43, 0.54, 0.62]
-    vd, n, e = direction_vector(48.0707, 128.53)
+    n, e, v = direction_vector(48.0707, 128.53)
     assert n == approx(-0.463438, rel=1e-5)
     assert e == approx(0.581993, rel=1e-5)
-    assert vd == approx(0.668214, rel=1e-5)
+    assert v == approx(0.668214, rel=1e-5)
 
 def test_north_west_down():
     #[-x  y -z]
     #[-0.87, 0.63, -0.94]
-    vd, n, e = direction_vector(48.8105, 144.09)
+    n, e, v = direction_vector(48.8105, 144.09)
     assert n == approx(-0.60951, rel=1e-5)
     assert e == approx(0.44137, rel=1e-5)
-    assert vd == approx(0.658551, rel=1e-5)
+    assert v == approx(0.658551, rel=1e-5)
 
 def test_south_west_up():
     #[-x -y  z]
     #[-0.77, -0.58, 0.84]
-    vd, n, e = direction_vector(48.9322, -143.011)
+    n, e, v = direction_vector(48.9322, -143.011)
     assert n == approx(-0.602206, rel=1e-5)
     assert e == approx(-0.45361, rel=1e-5)
-    assert vd == approx(0.656952, rel=1e-5)
+    assert v == approx(0.656952, rel=1e-5)
 
 def test_south_west_down():
     #[-x -y -z]
     #[-0.98, -0.49, -0.64]
-    vd, n, e = direction_vector(59.7101, -153.435)
+    n, e, v = direction_vector(59.7101, -153.435)
     assert n == approx(-0.772324, rel=1e-5)
     assert e == approx(-0.386162, rel=1e-5)
-    assert vd == approx(0.504375, rel=1e-5)
+    assert v == approx(0.504375, rel=1e-5)
 
 def test_array():
-    vd, n, e = direction_vector([59.7101, 48.9322], [-153.435, -143.011])
+    n, e, v = direction_vector([59.7101, 48.9322], [-153.435, -143.011])
     np.testing.assert_allclose(n, np.array([-0.772324, -0.602206]), rtol=1e-5)
     np.testing.assert_allclose(e, np.array([-0.386162, -0.45361]), rtol=1e-5)
-    np.testing.assert_allclose(vd, np.array([0.504375, 0.656952]), rtol=1e-5)
+    np.testing.assert_allclose(v, np.array([0.504375, 0.656952]), rtol=1e-5)
 
 from ..geometry import spherical
 
@@ -165,7 +165,7 @@ def test_spherical_position_roundtrip(n, e, v):
     n, e, v = normalize(n, e, v)
 
     inc, azi = spherical(n, e, v)
-    V, N, E = direction_vector(inc, azi)
+    N, E, V = direction_vector(inc, azi)
 
     if np.isnan(V):
         assert np.isnan(v)

--- a/wellpathpy/test/test_position_log.py
+++ b/wellpathpy/test/test_position_log.py
@@ -30,6 +30,8 @@ def test_resample_onto_unchanged_md(survey):
 
 def test_copy():
     original = position_log(np.array([]), np.array([1,2,3,4]), [4,3,2,1], [1,1,1,1])
+    original.resampled_md = (original.depth + 1)
     copy = original.copy()
     original.depth += 10
     np.testing.assert_equal([1,2,3,4], copy.depth)
+    np.testing.assert_equal([2,3,4,5], copy.resampled_md)


### PR DESCRIPTION
Compute a compatible deviation survey from a minimum curvature which,
save small differences introduced by the assumptions of the method, be
equivalent to the deviation survey used to derive the well path.

The method itself is rather well covered in docs and links, but getting
a working implementation up was quite the journey.

The initial implementation took the cartesian coordinates of the well
path and converted to spherical coordinates, and kept the measured-depth
around. This gave a reasonably close approximation, but the "measured"
inc/azi would locally be vastly different. I did not quite trace what
triggered the worst behaviour, but my guess is when the well made a
sharp turn.

I tried to reverse the min-curve formulae, but the inc/azi terms appear
way too often on the right-hand-side of the equations, and solving the
system with sympy proved infeasible if not impossible.

I kept coming back to tma's stackexchange answer, but did not really
take the time to understand it. When read carefully (and trying to
correct some typos) it seemed like it should work, and the effort
finally culminated to this patch. It relies only on geometry, and with
it the round trip deviation-survey -> position-log -> deviation-survey
becomes identity (for the data set at hand, the very least).

The implementation is probably a lot slower than it has to be, with its
generous allocations and explicit loop, but it does flow rather well.
With an implementation in place we now have a good foundation to get
some experience with real-world usage.

