### PR TITLE
Fix inconsistency in position_log method names

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -275,8 +275,8 @@ you can use the following functions which return a copy of the positional log by
 
 .. code-block:: python
 
-    pos_zero = pos_wellhead.loc_to_zero(surface_northing=surface_northing,
-                                        surface_easting=surface_easting)
+    pos_zero = pos_wellhead.to_zero(surface_northing=surface_northing,
+                                    surface_easting=surface_easting)
 
 .. image:: ./figures/loc_to_zero.png
     :width: 600
@@ -286,7 +286,7 @@ you can use the following functions which return a copy of the positional log by
 
 .. code-block:: python
 
-    pos_tvdss = pos.loc_to_tvdss(datum_elevation=header['elevation'])
+    pos_tvdss = pos.to_tvdss(datum_elevation=header['elevation'])
 
 .. image:: ./figures/loc_to_tvdss.png
     :width: 600

--- a/wellpathpy/location.py
+++ b/wellpathpy/location.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from .checkarrays import checkarrays_tvd
 
-def loc_to_wellhead(tvd, northing, easting, surface_northing, surface_easting):
+def to_wellhead(tvd, northing, easting, surface_northing, surface_easting):
     """Move deviation to wellhead location.
 
     Adds the surface location coordinates to the northing and easting arrays.
@@ -38,7 +38,7 @@ def loc_to_wellhead(tvd, northing, easting, surface_northing, surface_easting):
     return tvd, northing, easting
 
 
-def loc_to_zero(tvd, northing, easting, surface_northing, surface_easting):
+def to_zero(tvd, northing, easting, surface_northing, surface_easting):
     """Move deviation to zero coordinates.
 
     Substracts the surface location coordinates from the northing and easting arrays.
@@ -73,7 +73,7 @@ def loc_to_zero(tvd, northing, easting, surface_northing, surface_easting):
 
     return tvd, northing, easting
 
-def loc_to_tvdss(tvd, northing, easting, datum_elevation):
+def to_tvdss(tvd, northing, easting, datum_elevation):
     """
     Shift tvd to tvdss given datum elevation.
 

--- a/wellpathpy/position_log.py
+++ b/wellpathpy/position_log.py
@@ -133,7 +133,7 @@ class position_log:
         else:
             copy = self.copy()
 
-        depth, n, e = location.loc_to_wellhead(
+        depth, n, e = location.to_wellhead(
             copy.depth,
             copy.northing,
             copy.easting,
@@ -147,7 +147,7 @@ class position_log:
 
         return copy
 
-    def loc_to_zero(self, surface_northing, surface_easting, inplace = False):
+    def to_zero(self, surface_northing, surface_easting, inplace = False):
         """Create a new position log instance moved to 0m North and 0m East
 
         Parameters
@@ -161,7 +161,7 @@ class position_log:
         else:
             copy = self.copy()
 
-        depth, n, e = location.loc_to_zero(
+        depth, n, e = location.to_zero(
             copy.depth,
             copy.northing,
             copy.easting,
@@ -175,12 +175,12 @@ class position_log:
 
         return copy
 
-    def loc_to_tvdss(self, datum_elevation, inplace = False):
+    def to_tvdss(self, datum_elevation, inplace = False):
         """This function calls location.location_to_tvdss with self
 
         Notes
         -----
-            You can access help with `wp.location.loc_to_tvdss?`
+            You can access help with `wp.location.to_tvdss?`
             in `ipython`
         """
         if inplace:
@@ -188,7 +188,7 @@ class position_log:
         else:
             copy = self.copy()
 
-        depth, n, e = location.loc_to_tvdss(
+        depth, n, e = location.to_tvdss(
             copy.depth,
             copy.northing,
             copy.easting,

--- a/wellpathpy/test/test_calculations.py
+++ b/wellpathpy/test/test_calculations.py
@@ -6,7 +6,7 @@ import hypothesis
 from ..tan import tan_method
 from ..mincurve import minimum_curvature
 from ..rad_curv import radius_curvature
-from ..location import loc_to_wellhead
+from ..location import to_wellhead
 from ..position_log import deviation, position_log as mc
 
 # import test well data
@@ -39,8 +39,8 @@ well10_true_datum_elevation = 100 * 0.3048 # converting feet to meters
 def test_high_tan():
     tvd9, mN9, mE9 = tan_method(well9_true_md_m, well9_true_inc, well9_true_azi, choice='high')
     tvd10, mN10, mE10 = tan_method(well10_true_md_m, well10_true_inc, well10_true_azi, choice='high')
-    tvd9, mN9, mE9 = loc_to_wellhead(tvd9, mN9, mE9, 39998.454, 655701.278)
-    tvd10, mN10, mE10 = loc_to_wellhead(tvd10, mN10, mE10, 40004.564, 655701.377)
+    tvd9, mN9, mE9 = to_wellhead(tvd9, mN9, mE9, 39998.454, 655701.278)
+    tvd10, mN10, mE10 = to_wellhead(tvd10, mN10, mE10, 40004.564, 655701.377)
     np.testing.assert_allclose(tvd9, well9_true_tvd_m, atol=12)
     np.testing.assert_allclose(mE9, well9_true_easting, atol=12)
     np.testing.assert_allclose(mN9, well9_true_northing, atol=12)
@@ -51,8 +51,8 @@ def test_high_tan():
 def test_low_tan():
     tvd9, mN9, mE9 = tan_method(well9_true_md_m, well9_true_inc, well9_true_azi, choice='low')
     tvd10, mN10, mE10 = tan_method(well10_true_md_m, well10_true_inc, well10_true_azi, choice='low')
-    tvd9, mN9, mE9 = loc_to_wellhead(tvd9, mN9, mE9, 39998.454, 655701.278)
-    tvd10, mN10, mE10 = loc_to_wellhead(tvd10, mN10, mE10, 40004.564, 655701.377)
+    tvd9, mN9, mE9 = to_wellhead(tvd9, mN9, mE9, 39998.454, 655701.278)
+    tvd10, mN10, mE10 = to_wellhead(tvd10, mN10, mE10, 40004.564, 655701.377)
     np.testing.assert_allclose(tvd9, well9_true_tvd_m, atol=12)
     np.testing.assert_allclose(mE9, well9_true_easting, atol=12)
     np.testing.assert_allclose(mN9, well9_true_northing, atol=12)
@@ -63,8 +63,8 @@ def test_low_tan():
 def test_avg_tan():
     tvd9, mN9, mE9 = tan_method(well9_true_md_m, well9_true_inc, well9_true_azi, choice='avg')
     tvd10, mN10, mE10 = tan_method(well10_true_md_m, well10_true_inc, well10_true_azi, choice='avg')
-    tvd9, mN9, mE9 = loc_to_wellhead(tvd9, mN9, mE9, 39998.454, 655701.278)
-    tvd10, mN10, mE10 = loc_to_wellhead(tvd10, mN10, mE10, 40004.564, 655701.377)
+    tvd9, mN9, mE9 = to_wellhead(tvd9, mN9, mE9, 39998.454, 655701.278)
+    tvd10, mN10, mE10 = to_wellhead(tvd10, mN10, mE10, 40004.564, 655701.377)
     np.testing.assert_allclose(tvd9, well9_true_tvd_m, atol=10)
     np.testing.assert_allclose(mE9, well9_true_easting, atol=10)
     np.testing.assert_allclose(mN9, well9_true_northing, atol=10)
@@ -75,8 +75,8 @@ def test_avg_tan():
 def test_bal_tan():
     tvd9, mN9, mE9 = tan_method(well9_true_md_m, well9_true_inc, well9_true_azi, choice='bal')
     tvd10, mN10, mE10 = tan_method(well10_true_md_m, well10_true_inc, well10_true_azi, choice='bal')
-    tvd9, mN9, mE9 = loc_to_wellhead(tvd9, mN9, mE9, 39998.454, 655701.278)
-    tvd10, mN10, mE10 = loc_to_wellhead(tvd10, mN10, mE10, 40004.564, 655701.377)
+    tvd9, mN9, mE9 = to_wellhead(tvd9, mN9, mE9, 39998.454, 655701.278)
+    tvd10, mN10, mE10 = to_wellhead(tvd10, mN10, mE10, 40004.564, 655701.377)
     np.testing.assert_allclose(tvd9, well9_true_tvd_m, atol=10)
     np.testing.assert_allclose(mE9, well9_true_easting, atol=10)
     np.testing.assert_allclose(mN9, well9_true_northing, atol=10)
@@ -87,8 +87,8 @@ def test_bal_tan():
 def test_min_curve():
     tvd9, mN9, mE9, dls9 = minimum_curvature(well9_true_md_m, well9_true_inc, well9_true_azi)
     tvd10, mN10, mE10, dls10 = minimum_curvature(well10_true_md_m, well10_true_inc, well10_true_azi)
-    tvd9, mN9, mE9 = loc_to_wellhead(tvd9, mN9, mE9, 39998.454, 655701.278)
-    tvd10, mN10, mE10 = loc_to_wellhead(tvd10, mN10, mE10, 40004.564, 655701.377)
+    tvd9, mN9, mE9 = to_wellhead(tvd9, mN9, mE9, 39998.454, 655701.278)
+    tvd10, mN10, mE10 = to_wellhead(tvd10, mN10, mE10, 40004.564, 655701.377)
     np.testing.assert_allclose(tvd9, well9_true_tvd_m)
     np.testing.assert_allclose(mE9, well9_true_easting, atol=0.5)
     np.testing.assert_allclose(mN9, well9_true_northing, atol=0.5)
@@ -148,8 +148,8 @@ def test_min_curve_rf():
 def test_rad_curve():
     tvd9, mN9, mE9 = radius_curvature(well9_true_md_m, well9_true_inc, well9_true_azi)
     tvd10, mN10, mE10 = radius_curvature(well10_true_md_m, well10_true_inc, well10_true_azi)
-    tvd9, mN9, mE9 = loc_to_wellhead(tvd9, mN9, mE9, 39998.454, 655701.278)
-    tvd10, mN10, mE10 = loc_to_wellhead(tvd10, mN10, mE10, 40004.564, 655701.377)
+    tvd9, mN9, mE9 = to_wellhead(tvd9, mN9, mE9, 39998.454, 655701.278)
+    tvd10, mN10, mE10 = to_wellhead(tvd10, mN10, mE10, 40004.564, 655701.377)
     np.testing.assert_allclose(tvd9, well9_true_tvd_m, atol=1)
     np.testing.assert_allclose(mE9, well9_true_easting, atol=1)
     np.testing.assert_allclose(mN9, well9_true_northing, atol=1)

--- a/wellpathpy/test/test_location.py
+++ b/wellpathpy/test/test_location.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 
 from ..mincurve import minimum_curvature
-from ..location import loc_to_wellhead, loc_to_zero, loc_to_tvdss
+from ..location import to_wellhead, to_zero, to_tvdss
 
 # import test well data
 well9 = np.loadtxt('./wellpathpy/test/fixtures/well9.csv', delimiter=",", skiprows=1)
@@ -34,7 +34,7 @@ well10_true_datum_elevation = 100 * 0.3048 # converting feet to meters
 def test_wellhead():
     # test well9
     well9_tvd, well9_northing, well9_easting, _ = minimum_curvature(well9_true_md_m, well9_true_inc, well9_true_azi)
-    tvd, mN, mE = loc_to_wellhead(
+    tvd, mN, mE = to_wellhead(
         well9_tvd,
         well9_northing,
         well9_easting,
@@ -46,7 +46,7 @@ def test_wellhead():
     np.testing.assert_allclose(mE, well9_true_easting, atol=1)
     # test well10
     well10_tvd, well10_northing, well10_easting, _ = minimum_curvature(well10_true_md_m, well10_true_inc, well10_true_azi)
-    tvd, mN, mE = loc_to_wellhead(
+    tvd, mN, mE = to_wellhead(
         well10_tvd,
         well10_northing,
         well10_easting,
@@ -60,7 +60,7 @@ def test_wellhead():
 def test_zero():
     # test well9
     _, well9_northing, well9_easting, _ = minimum_curvature(well9_true_md_m, well9_true_inc, well9_true_azi)
-    tvd, mN, mE = loc_to_zero(
+    tvd, mN, mE = to_zero(
         well9_true_tvd_m,
         well9_true_northing,
         well9_true_easting,
@@ -72,7 +72,7 @@ def test_zero():
     np.testing.assert_allclose(mE, well9_easting, atol=1)
     # test well10
     _, well10_northing, well10_easting, _ = minimum_curvature(well10_true_md_m, well10_true_inc, well10_true_azi)
-    tvd, mN, mE = loc_to_zero(
+    tvd, mN, mE = to_zero(
         well10_true_tvd_m,
         well10_true_northing,
         well10_true_easting,
@@ -86,7 +86,7 @@ def test_zero():
 def test_tvdss():
     # test well9
     well9_tvd, well9_northing, well9_easting, _ = minimum_curvature(well9_true_md_m, well9_true_inc, well9_true_azi)
-    tvdss, mN, mE = loc_to_tvdss(
+    tvdss, mN, mE = to_tvdss(
         well9_tvd,
         well9_northing,
         well9_easting,
@@ -97,7 +97,7 @@ def test_tvdss():
     np.testing.assert_equal(mE, well9_easting)
     # test well10
     well10_tvd, well10_northing, well10_easting, _ = minimum_curvature(well10_true_md_m, well10_true_inc, well10_true_azi)
-    tvdss, mN, mE = loc_to_tvdss(
+    tvdss, mN, mE = to_tvdss(
         well10_tvd,
         well10_northing,
         well10_easting,


### PR DESCRIPTION
The "loc" prefix brought nothing useful to the API and so this
commit aligns all these methods onto a nicer interface following
the "to_<something>" pattern. This fixes issue #28.