### PR TITLE
removing deprecation warnings re numpy type aliases

### DIFF
--- a/wellpathpy/checkarrays.py
+++ b/wellpathpy/checkarrays.py
@@ -38,9 +38,9 @@ def checkarrays(md, inc, azi):
         If the md values are not strictly increasing
         If NaN values are included in md, inc or azi
     """
-    md = np.asarray(md, dtype = np.float)
-    inc = np.asarray(inc, dtype = np.float)
-    azi = np.asarray(azi, dtype = np.float)
+    md = np.asarray(md, dtype=float)
+    inc = np.asarray(inc, dtype=float)
+    azi = np.asarray(azi, dtype=float)
 
     for prop, arr in {'md': md, 'inc': inc, 'azi': azi}.items():
         if np.isnan(arr).any():
@@ -96,9 +96,9 @@ def checkarrays_tvd(tvd, northing, easting):
         If tvd, northing, or easting, are of different shapes
         If NaN values are included in tvd, easting or northing
     """
-    tvd = np.asarray(tvd, dtype = np.float)
-    northing = np.asarray(northing, dtype = np.float)
-    easting = np.asarray(easting, dtype = np.float)
+    tvd = np.asarray(tvd, dtype=float)
+    northing = np.asarray(northing, dtype=float)
+    easting = np.asarray(easting, dtype=float)
 
     for prop, arr in {'tvd': tvd, 'northing': northing, 'easting': easting}.items():
         if np.isnan(arr).any():


### PR DESCRIPTION
I was getting deprecation warnings in `welly` from these type conversions. Using aliases was deprecated in NumPy v 1.20.0: https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated

The fix proposed here seemed like the simplest solution works for me. From those docs:

> For `np.int` a direct replacement with `np.int_` or `int` is also good and will not change behavior