### PR TITLE
Compute vector angle with arctan for stability

### DIFF
--- a/wellpathpy/geometry.py
+++ b/wellpathpy/geometry.py
@@ -1,5 +1,35 @@
 import numpy as np
 
+def direction_vector_radians(inc, azi):
+    """(inc, azi) -> [N E V]
+
+    Convert spherical coordinates (inc, azi) in radians to cubic coordinates
+    (northing, easting, vertical depth), a unit length direction vector in a
+    right handed coordinate system.
+
+    Parameters
+    ----------
+    inc : array_like of float
+        inclination in radians
+    azi : array_like of float
+        azimuth in radians
+
+    Returns
+    -------
+    northing : array_like of float
+    easting : array_like of float
+    vd : array_like of float
+        vertial direction
+
+    See also
+    --------
+    direction_vector
+    """
+    vd = np.cos(inc)
+    northing = np.sin(inc) * np.cos(azi)
+    easting  = np.sin(inc) * np.sin(azi)
+    return northing, easting, vd
+
 def direction_vector(inc, azi):
     """(inc, azi) -> [N E V]
 
@@ -38,13 +68,8 @@ def direction_vector(inc, azi):
 
     """
     inc = np.deg2rad(inc)
-    az = np.deg2rad(azi)
-
-    vd = np.cos(inc)
-    northing = np.sin(inc) * np.cos(az)
-    easting  = np.sin(inc) * np.sin(az)
-
-    return northing, easting, vd
+    azi = np.deg2rad(azi)
+    return direction_vector_radians(inc, azi)
 
 def spherical(northing, easting, depth):
     """[N E V] -> (inc, azi)

--- a/wellpathpy/geometry.py
+++ b/wellpathpy/geometry.py
@@ -168,13 +168,13 @@ def unit_vector(v):
     """
     return normalize(v)
 
-def angle_between(v1, v2):
+def angle_between(u, v):
     """Return the angle between (arrays of) vectors
 
     Parameters
     ----------
-    v1 : array_like
-    v2 : array_like
+    u : array_like
+    v : array_like
 
     Returns
     -------
@@ -194,20 +194,14 @@ def angle_between(v1, v2):
     >>> angle_between(a, b)
     [1.5707963267948966]
     """
-    # The angle between vectors is computed from the dot-product, but we want
-    # to also do this for arrays-of-vectors, and np.dot() interprets that as
-    # matrix multiplication.
-    v1 = normalize(v1)
-    v2 = normalize(v2)
-    if v1.ndim == 1:
-        dot = np.dot(v1, v2)
-    else:
-        # This is just a way of writing dot(v1,v2) for an array-of-vectors
-        dot = np.einsum('ij,ij->i', v1, v2)
-
-    # arccos is only defined [-1,1], dot can _sometimes_ go outside this domain
-    # because of floating points
-    return np.arccos(np.clip(dot, -1.0, 1.0))
+    ndims = np.ndim(u)
+    is_1d = ndims == 1
+    u = np.atleast_2d(normalize(u))
+    v = np.atleast_2d(normalize(v))
+    norm_sub = np.linalg.norm(v - u, axis = 1)
+    norm_add = np.linalg.norm(v + u, axis = 1)
+    angle = 2.0 * np.arctan(norm_sub / norm_add)
+    return angle[0] if is_1d else angle
 
 def normal_vector(v1, v2):
     """Normal vector to plane given by vectors v1 and v2

--- a/wellpathpy/mincurve.py
+++ b/wellpathpy/mincurve.py
@@ -40,10 +40,9 @@ def minimum_curvature_inner(md, inc, azi):
     upper, lower = dv[:-1], dv[1:]
     dogleg = angle_between(upper, lower)
 
-    # ratio factor, correct for dogleg == 0 values
-    with np.errstate(divide = 'ignore', invalid = 'ignore'):
-        rf = 2 / dogleg * np.tan(dogleg / 2)
-        rf = np.where(dogleg == 0., 1, rf)
+    # ratio factor, correct for dogleg == 0 values to avoid divide-by-zero
+    dogleg[dogleg == 0] = 1.0
+    rf = 2 / dogleg * np.tan(dogleg / 2)
 
     md_diff  = md[1:] - md[:-1]
     halfmd   = md_diff / 2

--- a/wellpathpy/mincurve.py
+++ b/wellpathpy/mincurve.py
@@ -1,6 +1,8 @@
 import numpy as np
 
 from .checkarrays import checkarrays
+from .geometry import angle_between
+from .geometry import direction_vector_radians
 
 def minimum_curvature_inner(md, inc, azi):
     """Calculate TVD, northing, easting, and dogleg, using the minimum curvature
@@ -36,11 +38,10 @@ def minimum_curvature_inner(md, inc, azi):
     inc_upper, inc_lower = inc[:-1], inc[1:]
     azi_upper, azi_lower = azi[:-1], azi[1:]
 
-    cos_inc = np.cos(inc_lower - inc_upper)
-    sin_inc = np.sin(inc_upper) * np.sin(inc_lower)
-    cos_azi = 1 - np.cos(azi_lower - azi_upper)
-
-    dogleg = np.arccos(cos_inc - (sin_inc * cos_azi))
+    dv = direction_vector_radians(inc, azi)
+    dv = np.column_stack(dv)
+    upper, lower = dv[:-1], dv[1:]
+    dogleg = angle_between(upper, lower)
 
     # ratio factor, correct for dogleg == 0 values
     with np.errstate(divide = 'ignore', invalid = 'ignore'):

--- a/wellpathpy/mincurve.py
+++ b/wellpathpy/mincurve.py
@@ -31,8 +31,6 @@ def minimum_curvature_inner(md, inc, azi):
     dogleg : array_like of float
 
     """
-    md, inc, azi = checkarrays(md, inc, azi)
-
     # Compute the direction vectors for the surveys and organise them as
     # (upper, lower) pairs, by index in the arrays.
     dv = direction_vector_radians(inc, azi)

--- a/wellpathpy/mincurve.py
+++ b/wellpathpy/mincurve.py
@@ -33,11 +33,8 @@ def minimum_curvature_inner(md, inc, azi):
     """
     md, inc, azi = checkarrays(md, inc, azi)
 
-    # extract upper and lower survey stations
-    md_upper, md_lower = md[:-1], md[1:]
-    inc_upper, inc_lower = inc[:-1], inc[1:]
-    azi_upper, azi_lower = azi[:-1], azi[1:]
-
+    # Compute the direction vectors for the surveys and organise them as
+    # (upper, lower) pairs, by index in the arrays.
     dv = direction_vector_radians(inc, azi)
     dv = np.column_stack(dv)
     upper, lower = dv[:-1], dv[1:]
@@ -48,18 +45,11 @@ def minimum_curvature_inner(md, inc, azi):
         rf = 2 / dogleg * np.tan(dogleg / 2)
         rf = np.where(dogleg == 0., 1, rf)
 
-    md_diff = md_lower - md_upper
-
-    upper = np.sin(inc_upper) * np.cos(azi_upper)
-    lower = np.sin(inc_lower) * np.cos(azi_lower)
-    northing = np.cumsum((md_diff / 2) * (upper + lower) * rf)
-
-    upper = np.sin(inc_upper) * np.sin(azi_upper)
-    lower = np.sin(inc_lower) * np.sin(azi_lower)
-    easting = np.cumsum((md_diff / 2) * (upper + lower) * rf)
-
-    tvd = np.cumsum((md_diff / 2) * (np.cos(inc_upper) + np.cos(inc_lower)) * rf)
-
+    md_diff  = md[1:] - md[:-1]
+    halfmd   = md_diff / 2
+    northing = np.cumsum(halfmd * (upper[:, 0] + lower[:, 0]) * rf)
+    easting  = np.cumsum(halfmd * (upper[:, 1] + lower[:, 1]) * rf)
+    tvd      = np.cumsum(halfmd * (upper[:, 2] + lower[:, 2]) * rf)
     return tvd, northing, easting, dogleg
 
 def minimum_curvature(md, inc, azi, course_length=30):

--- a/wellpathpy/read.py
+++ b/wellpathpy/read.py
@@ -49,5 +49,8 @@ def read_csv(fname, delimiter=',', skiprows=1, **kwargs):
     dev = np.loadtxt(fname, delimiter=delimiter, skiprows=skiprows, **kwargs)
     md, inc, azi = np.split(dev[:,0:3], 3, 1)
     md, inc, azi = checkarrays(md, inc, azi)
+    md  = md.flatten()
+    inc = inc.flatten()
+    azi = azi.flatten()
 
     return md, inc, azi


### PR DESCRIPTION
Compute the angle between two vectors using arctan for a more
numerically stable solution for very small angles. This comes with a
small speed loss, but much greater accuracy.

The code [1] was proposed by David Baker.

> You are using the inverse cosine calculate the angle between two
> vectors. This is notoriously problematic . It is unstable when the
> vectors are near (anti-)parallel , it has an asymptotically
> vanishing first derivative. This means in straight hole conditions
> errors in the data are amplified. A better method is this:

[1] https://github.com/Zabamund/wellpathpy/issues/36

--

Use the direction_vector computed vectors rather than inline
trigonometry to compute the position log. These are computed anyway in
order to use angle_between for the dogleg, so it makes sense to reuse
them. On top of doing less work this improves the clarity of the
function significantly, at the cost of move it one step away from the
textbook formulae.