### PR TITLE
Transpose write.deviation_to_csv and write.position_to_csv output to column format for user ease

### DIFF
--- a/wellpathpy/write.py
+++ b/wellpathpy/write.py
@@ -41,7 +41,7 @@ def deviation_to_csv(fname, md, inc, azi, fmt='%.3f', delimiter=',', header='md,
     md, inc, azi = checkarrays(md, inc, azi)
 
     a = np.asarray([md, inc, azi])
-    np.savetxt(fname, a, fmt=fmt, delimiter=delimiter, header=header, **kwargs)
+    np.savetxt(fname, a.T, fmt=fmt, delimiter=delimiter, header=header, **kwargs)
 
     return None
 
@@ -85,6 +85,6 @@ def position_to_csv(fname, depth, northing, easting, fmt='%.3f', delimiter=',', 
     depth, northing, easting = checkarrays_tvd(depth, northing, easting)
 
     a = np.asarray([easting, northing, depth])
-    np.savetxt(fname, a, fmt=fmt, delimiter=delimiter, header=header, **kwargs)
+    np.savetxt(fname, a.T, fmt=fmt, delimiter=delimiter, header=header, **kwargs)
 
     return None


### PR DESCRIPTION
Enhancement #58 - `md, inc, azi` and `tvd, e, n` arrays are returned horizontally (rows). PR passes `a.T` to `np.savetext` in the `position_to_csv` and `deviation_to_csv` functions (`write.py`) to transpose arrays for output as columns. 

Thanks. 