### PR TITLE
Snap zero-angle ratio factor correctly

### DIFF
--- a/wellpathpy/mincurve.py
+++ b/wellpathpy/mincurve.py
@@ -38,9 +38,16 @@ def minimum_curvature_inner(md, inc, azi):
     upper, lower = dv[:-1], dv[1:]
     dogleg = angle_between(upper, lower)
 
-    # ratio factor, correct for dogleg == 0 values to avoid divide-by-zero
-    dogleg[dogleg == 0] = 1.0
-    rf = 2 / dogleg * np.tan(dogleg / 2)
+    # ratio factor, correct for dogleg == 0 values to avoid divide-by-zero.
+    # While undefined for dl = 0 it reasonably evaluates to 1:
+    #   >>> def rf(x): return (2 * np.tan(x/2))/x
+    #   >>> rf(1e-10)
+    #   1.0
+    z  = np.where(dogleg == 0)
+    nz = np.where(dogleg != 0)
+    rf = 2 * np.tan(dogleg / 2)
+    rf[nz] /= dogleg[nz]
+    rf[z] = 1
 
     md_diff  = md[1:] - md[:-1]
     halfmd   = md_diff / 2

--- a/wellpathpy/test/test_position_log.py
+++ b/wellpathpy/test/test_position_log.py
@@ -39,6 +39,34 @@ def test_copy():
     original.depth += 10
     np.testing.assert_equal([1,2,3,4], copy.depth)
 
+def test_straight_down_segment_preserves_depth():
+    """
+    When the well is straight down, the vertical depth and measured depth
+    should increase at the same rate.
+    """
+    md  = [0, 3, 7]
+    inc = [0, 0, 0]
+    azi = [0, 0, 0]
+
+    pos = deviation(md, inc, azi).minimum_curvature()
+    np.testing.assert_array_equal(md, pos.depth)
+    np.testing.assert_array_equal([0, 0, 0], pos.northing)
+    np.testing.assert_array_equal([0, 0, 0], pos.easting)
+
+def test_straight_nonvertical_segment():
+    """
+    The well has a constant inclination which means delta(md) > delta(vd), the
+    path is not straight down. This doesn't test for the path going back up.
+    """
+    md  = np.array([1,  3,  7])
+    inc = np.array([30, 30, 30])
+    azi = np.array([0, 0, 0])
+
+    pos = deviation(md, inc, azi).minimum_curvature()
+    delta_md = md[1:] - md[:-1]
+    delta_vd = pos.depth[1:] - pos.depth[:-1]
+    assert (delta_md > delta_vd).all()
+
 @pytest.mark.xfail(strict = True)
 def test_straight_hole():
     md = np.array([0, 10, 20]).reshape(3, 1)


### PR DESCRIPTION
When the dogleg angle is zero (no change between two survey stations)
there is no dampening effect and the ratio factor should be one 1, but
the divide-by-zero must be handled. This already happens in practice for
very small angles [1] but the implementation was buggy and applied the 1
to the dogleg, not the rf.

[1]
```
>>> def rf(x): return (2 * np.tan(x/2))/x
>>> rf(1e-10)
1.0
```