### PR TITLE
Update docs for basic task: getting tvd, northing and easting from md, inc, azi

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -237,7 +237,10 @@ You can then run the following methods once you've imported your :ref:`deviation
 .. code-block:: python
 
     # The recommended method for most use-cases
-    tvd, northing, easting, dls = dev.mininum_curvature(course_length=30)
+    pos = dev.mininum_curvature(course_length=30)
+    tvd = pos.depth
+    northing = pos.northing
+    easting = pos.easting
 
     # Comparison methods to contrast with older deviation surveys
     tvd, northing, easting      = dev.radius_curvature()


### PR DESCRIPTION
When trying to go from three arrays for MD, inclination and azimuth, to TVD, easting and northing, the [documentation](https://wellpathpy.readthedocs.io/en/latest/tutorial.html#converting-deviation-surveys-to-positional-logs) is misleading. It suggests:

```python
dev = wp.deviation(
    md = md,
    inc = inc,
    azi = azi,
    )
tvd, northing, easting, dls = dev.mininum_curvature(course_length=30)
```

but the second line here results in an error - my code:

```python
dev = wp.deviation(md=df.index, inc=df['TILT'], azi=df['AZIMUT'])
tvd, northing, easting, dls = dev.minimum_curvature()
```

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Input In [35], in <cell line: 2>()
      9     y = float(las.well.NORTHING.value)
     10     dev = wp.deviation(md=df.index, inc=df['TILT'], azi=df['AZIMUT'])
---> 11     tvd, northing, easting, dls = dev.minimum_curvature()
     12     dhs.append({
     13         "las": las,
     14         "df": df,
   (...)
     17         "y": y
     18     })
     19 dh_df = pd.DataFrame(dhs)

TypeError: cannot unpack non-iterable minimum_curvature object
```

The PR updates the docs example to reflect how the package appears to work instead.