### PR TITLE
get package version using importlib

### DIFF
--- a/wellpathpy/__init__.py
+++ b/wellpathpy/__init__.py
@@ -1,8 +1,9 @@
-try:
-    import pkg_resources
-    __version__ = pkg_resources.get_distribution(__name__).version
-except pkg_resources.DistributionNotFound:
-    pass
+import sys
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
+__version__ = metadata.version(__name__)
 
 __all__ = [
     'read_header_json',


### PR DESCRIPTION
This pull request replaces `pkg_resources` with `importlib` for getting the package version.
It fixes #70 following the suggestion by @ShadowsInRain, and I've verified that it passes unit tests on my system.