### PR TITLE
Update pyproject.toml - bump numpy version 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ license = { file = "LICENSE" }
 platforms = "any"
 
 dependencies = [
-    "numpy >=1.10",
+    "numpy >=1.26.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Update to better support python 3.12. 

The current numpy >=1.10 requirement is impossible to satisfy on Python 3.12, since NumPy versions 1.10-1.25 don't support Python 3.12.